### PR TITLE
Use correct function prototype for linux kernel >= 6.9.

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -1071,7 +1071,7 @@ static void rwnx_csa_finish(struct work_struct *ws)
         } else
             rwnx_txq_vif_stop(vif, RWNX_TXQ_STOP_CHAN, rwnx_hw);
         spin_unlock_bh(&rwnx_hw->cb_lock);
-#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION3)
+#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION3 && LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0))
 		cfg80211_ch_switch_notify(vif->ndev, &csa->chandef, 0, 0);
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
 		cfg80211_ch_switch_notify(vif->ndev, &csa->chandef, 0);
@@ -4694,7 +4694,7 @@ int rwnx_cfg80211_channel_switch(struct wiphy *wiphy,
         goto end;
     } else {
         INIT_WORK(&csa->work, rwnx_csa_finish);
-#if LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION4
+#if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION4 && LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0))
 		cfg80211_ch_switch_started_notify(dev, &csa->chandef, 0, params->count, false, 0);
 #elif LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2
         cfg80211_ch_switch_started_notify(dev, &csa->chandef, 0, params->count, false);


### PR DESCRIPTION
Starting from linux version 6.9.0, functions
* cfg_80211_ch_switch_notify
* cfg_80211_ch_switch_started_notify

don't take puncturing parameter anymore.

See commit `b82730bf57b54803ab94abbfd8c4422a7081886d` in the linux kernel for reference.