### PR TITLE
fix kernel 6.15 compile error

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/aicwf_sdio.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_sdio.c
@@ -527,7 +527,7 @@ static void aicwf_sdio_bus_stop(struct device *dev)
 
     aicwf_sdio_pwrctl_timer(sdiodev, 0);
     if(timer_pending(&sdiodev->rwnx_hw->p2p_alive_timer)){
-        ret = del_timer(&sdiodev->rwnx_hw->p2p_alive_timer);}
+        ret = timer_delete(&sdiodev->rwnx_hw->p2p_alive_timer);}
     sdio_dbg("%s\n",__func__);
     if (sdiodev->pwrctl_tsk) {
         complete(&sdiodev->pwrctrl_trgg);
@@ -1080,7 +1080,7 @@ void aicwf_sdio_pwrctl_timer(struct aic_sdio_dev *sdiodev, uint duration)
     spin_lock_bh(&sdiodev->pwrctl_lock);
     if (!duration) {
         if (timer_pending(&sdiodev->timer))
-            del_timer_sync(&sdiodev->timer);
+            timer_delete_sync(&sdiodev->timer);
     } else {
         sdiodev->active_duration = duration;
         timeout = msecs_to_jiffies(sdiodev->active_duration);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_sdio.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_sdio.c
@@ -527,7 +527,12 @@ static void aicwf_sdio_bus_stop(struct device *dev)
 
     aicwf_sdio_pwrctl_timer(sdiodev, 0);
     if(timer_pending(&sdiodev->rwnx_hw->p2p_alive_timer)){
-        ret = timer_delete(&sdiodev->rwnx_hw->p2p_alive_timer);}
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+            ret = timer_delete(&sdiodev->rwnx_hw->p2p_alive_timer);
+        #else
+            ret = del_timer(&sdiodev->rwnx_hw->p2p_alive_timer);
+        #endif
+    }
     sdio_dbg("%s\n",__func__);
     if (sdiodev->pwrctl_tsk) {
         complete(&sdiodev->pwrctrl_trgg);
@@ -1080,7 +1085,11 @@ void aicwf_sdio_pwrctl_timer(struct aic_sdio_dev *sdiodev, uint duration)
     spin_lock_bh(&sdiodev->pwrctl_lock);
     if (!duration) {
         if (timer_pending(&sdiodev->timer))
-            timer_delete_sync(&sdiodev->timer);
+            #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+                timer_delete_sync(&sdiodev->timer);
+            #else
+                del_timer_sync(&sdiodev->timer);
+            #endif
     } else {
         sdiodev->active_duration = duration;
         timeout = msecs_to_jiffies(sdiodev->active_duration);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
@@ -106,7 +106,11 @@ void tcp_ack_deinit(struct rwnx_hw *priv)
 		drop_msg = NULL;
 
 		write_seqlock_bh(&ack_m->ack_info[i].seqlock);
-		timer_delete(&ack_m->ack_info[i].timer);
+		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+			timer_delete(&ack_m->ack_info[i].timer);
+		#else
+			del_timer(&ack_m->ack_info[i].timer);
+		#endif
 		drop_msg = ack_m->ack_info[i].msgbuf;
 		ack_m->ack_info[i].msgbuf = NULL;
 		write_sequnlock_bh(&ack_m->ack_info[i].seqlock);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
@@ -375,7 +375,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
 				//printk("%lx \n",ack_info->msgbuf);
 				drop_msg = ack_info->msgbuf;
 				ack_info->msgbuf = NULL;
-				timer_delete(&ack_info->timer);
+				#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+					timer_delete(&ack_info->timer);
+				#else
+					del_timer(&ack_info->timer);
+				#endif
 			}else{
 				//printk("msgbuf is NULL \n");
 			}
@@ -409,7 +413,11 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
 				   atomic_read(&ack_m->max_drop_cnt)))) {
 			ack_info->drop_cnt = 0;
 			ack_info->in_send_msg = new_msgbuf;
-			timer_delete(&ack_info->timer);
+			#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+    			timer_delete(&ack_info->timer);
+			#else
+				del_timer(&ack_info->timer);
+			#endif
 		} else {
 			ret = 1;
 			ack_info->msgbuf = new_msgbuf;
@@ -472,7 +480,11 @@ int tcp_ack_handle_new(struct msg_buf *new_msgbuf,
 			ack_info->drop_cnt = 0;
 			send_msg = new_msgbuf;
 			ack_info->in_send_msg = send_msg;
-			timer_delete(&ack_info->timer);
+			#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+    			timer_delete(&ack_info->timer);
+			#else
+				del_timer(&ack_info->timer);
+			#endif
 		}else{
 			ret = 1;
 			ack_info->msgbuf = new_msgbuf;

--- a/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_tcp_ack.c
@@ -106,7 +106,7 @@ void tcp_ack_deinit(struct rwnx_hw *priv)
 		drop_msg = NULL;
 
 		write_seqlock_bh(&ack_m->ack_info[i].seqlock);
-		del_timer(&ack_m->ack_info[i].timer);
+		timer_delete(&ack_m->ack_info[i].timer);
 		drop_msg = ack_m->ack_info[i].msgbuf;
 		ack_m->ack_info[i].msgbuf = NULL;
 		write_sequnlock_bh(&ack_m->ack_info[i].seqlock);
@@ -375,7 +375,7 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
 				//printk("%lx \n",ack_info->msgbuf);
 				drop_msg = ack_info->msgbuf;
 				ack_info->msgbuf = NULL;
-				del_timer(&ack_info->timer);
+				timer_delete(&ack_info->timer);
 			}else{
 				//printk("msgbuf is NULL \n");
 			}
@@ -409,7 +409,7 @@ int tcp_ack_handle(struct msg_buf *new_msgbuf,
 				   atomic_read(&ack_m->max_drop_cnt)))) {
 			ack_info->drop_cnt = 0;
 			ack_info->in_send_msg = new_msgbuf;
-			del_timer(&ack_info->timer);
+			timer_delete(&ack_info->timer);
 		} else {
 			ret = 1;
 			ack_info->msgbuf = new_msgbuf;
@@ -472,7 +472,7 @@ int tcp_ack_handle_new(struct msg_buf *new_msgbuf,
 			ack_info->drop_cnt = 0;
 			send_msg = new_msgbuf;
 			ack_info->in_send_msg = send_msg;
-			del_timer(&ack_info->timer);
+			timer_delete(&ack_info->timer);
 		}else{
 			ret = 1;
 			ack_info->msgbuf = new_msgbuf;

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -2483,7 +2483,7 @@ static void aicwf_usb_disconnect(struct usb_interface *intf)
 #if 0
 	if(timer_pending(&usb_dev->rwnx_hw->p2p_alive_timer) && usb_dev->rwnx_hw->is_p2p_alive == 1){
 		printk("%s del timer rwnx_hw->p2p_alive_timer \r\n", __func__);
-		rwnx_timer_delete(&usb_dev->rwnx_hw->p2p_alive_timer);
+		rwnx_del_timer(&usb_dev->rwnx_hw->p2p_alive_timer);
 	}
 #endif
     aicwf_bus_deinit(usb_dev->dev);

--- a/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
+++ b/drivers/aic8800/aic8800_fdrv/aicwf_usb.c
@@ -2483,7 +2483,7 @@ static void aicwf_usb_disconnect(struct usb_interface *intf)
 #if 0
 	if(timer_pending(&usb_dev->rwnx_hw->p2p_alive_timer) && usb_dev->rwnx_hw->is_p2p_alive == 1){
 		printk("%s del timer rwnx_hw->p2p_alive_timer \r\n", __func__);
-		rwnx_del_timer(&usb_dev->rwnx_hw->p2p_alive_timer);
+		rwnx_timer_delete(&usb_dev->rwnx_hw->p2p_alive_timer);
 	}
 #endif
     aicwf_bus_deinit(usb_dev->dev);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2191,7 +2191,7 @@ static int rwnx_cfg80211_del_iface(struct wiphy *wiphy, struct wireless_dev *wde
 #if 0
 	if (rwnx_vif == rwnx_hw->p2p_dev_vif) {
 		if (timer_pending(&rwnx_hw->p2p_alive_timer)) {
-			del_timer_sync(&rwnx_hw->p2p_alive_timer);
+			timer_delete_sync(&rwnx_hw->p2p_alive_timer);
 		}
 	}
 #endif
@@ -2440,7 +2440,7 @@ static void rwnx_cfgp2p_stop_p2p_device(struct wiphy *wiphy, struct wireless_dev
 	if (rwnx_vif == rwnx_hw->p2p_dev_vif) {
 		rwnx_hw->is_p2p_alive = 0;
 		if (timer_pending(&rwnx_hw->p2p_alive_timer)) {
-			del_timer_sync(&rwnx_hw->p2p_alive_timer);
+			timer_delete_sync(&rwnx_hw->p2p_alive_timer);
 		}
 		if (rwnx_vif->up) {
 			rwnx_send_remove_if(rwnx_hw, rwnx_vif->vif_index, true);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2191,7 +2191,11 @@ static int rwnx_cfg80211_del_iface(struct wiphy *wiphy, struct wireless_dev *wde
 #if 0
 	if (rwnx_vif == rwnx_hw->p2p_dev_vif) {
 		if (timer_pending(&rwnx_hw->p2p_alive_timer)) {
-			timer_delete_sync(&rwnx_hw->p2p_alive_timer);
+			#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+                timer_delete_sync(&rwnx_hw->p2p_alive_timer);
+            #else
+                del_timer_sync(&rwnx_hw->p2p_alive_timer);
+            #endif
 		}
 	}
 #endif
@@ -2440,7 +2444,11 @@ static void rwnx_cfgp2p_stop_p2p_device(struct wiphy *wiphy, struct wireless_dev
 	if (rwnx_vif == rwnx_hw->p2p_dev_vif) {
 		rwnx_hw->is_p2p_alive = 0;
 		if (timer_pending(&rwnx_hw->p2p_alive_timer)) {
-			timer_delete_sync(&rwnx_hw->p2p_alive_timer);
+			#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+                timer_delete_sync(&rwnx_hw->p2p_alive_timer);
+            #else
+                del_timer_sync(&rwnx_hw->p2p_alive_timer);
+            #endif
 		}
 		if (rwnx_vif->up) {
 			rwnx_send_remove_if(rwnx_hw, rwnx_vif->vif_index, true);

--- a/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
@@ -1428,7 +1428,11 @@ int reord_flush_tid(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u8 tid)
     preorder_ctrl->enable = false;
     spin_unlock_irqrestore(&preorder_ctrl->reord_list_lock, flags);
     if (timer_pending(&preorder_ctrl->reord_timer))
-        ret = timer_delete_sync(&preorder_ctrl->reord_timer);
+        #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+            ret = timer_delete_sync(&preorder_ctrl->reord_timer);
+        #else
+            ret = del_timer_sync(&preorder_ctrl->reord_timer);
+        #endif
     cancel_work_sync(&preorder_ctrl->reord_timer_work);
 
     return 0;
@@ -1454,7 +1458,11 @@ void reord_deinit_sta(struct aicwf_rx_priv* rx_priv, struct reord_ctrl_info *reo
 		if(preorder_ctrl->enable){
 			preorder_ctrl->enable = false;
 	        if (timer_pending(&preorder_ctrl->reord_timer)) {
-	            ret = timer_delete_sync(&preorder_ctrl->reord_timer);
+	            #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+                    ret = timer_delete_sync(&preorder_ctrl->reord_timer);
+                #else
+                    ret = del_timer_sync(&preorder_ctrl->reord_timer);
+                #endif
 	        }
 	        cancel_work_sync(&preorder_ctrl->reord_timer_work);
 		}
@@ -1833,7 +1841,11 @@ int reord_process_unit(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u16 s
         }
     } else {
 		if(timer_pending(&preorder_ctrl->reord_timer)) {
-	        	ret = timer_delete(&preorder_ctrl->reord_timer);
+	        	#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+                    ret = timer_delete(&preorder_ctrl->reord_timer);
+                #else
+                    ret = del_timer(&preorder_ctrl->reord_timer);
+                #endif
 		}
     }
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
@@ -1428,7 +1428,7 @@ int reord_flush_tid(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u8 tid)
     preorder_ctrl->enable = false;
     spin_unlock_irqrestore(&preorder_ctrl->reord_list_lock, flags);
     if (timer_pending(&preorder_ctrl->reord_timer))
-        ret = del_timer_sync(&preorder_ctrl->reord_timer);
+        ret = timer_delete_sync(&preorder_ctrl->reord_timer);
     cancel_work_sync(&preorder_ctrl->reord_timer_work);
 
     return 0;
@@ -1454,7 +1454,7 @@ void reord_deinit_sta(struct aicwf_rx_priv* rx_priv, struct reord_ctrl_info *reo
 		if(preorder_ctrl->enable){
 			preorder_ctrl->enable = false;
 	        if (timer_pending(&preorder_ctrl->reord_timer)) {
-	            ret = del_timer_sync(&preorder_ctrl->reord_timer);
+	            ret = timer_delete_sync(&preorder_ctrl->reord_timer);
 	        }
 	        cancel_work_sync(&preorder_ctrl->reord_timer_work);
 		}
@@ -1833,7 +1833,7 @@ int reord_process_unit(struct aicwf_rx_priv *rx_priv, struct sk_buff *skb, u16 s
         }
     } else {
 		if(timer_pending(&preorder_ctrl->reord_timer)) {
-	        	ret = del_timer(&preorder_ctrl->reord_timer);
+	        	ret = timer_delete(&preorder_ctrl->reord_timer);
 		}
     }
 


### PR DESCRIPTION
rename functions (old function names were removed from kernel)

del_timer() -> timer_delete()
del_timer_sync() -> timer_delete_sync()