### PR TITLE
fix compilation error for kernel 6.17

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -4278,7 +4278,11 @@ void rwnx_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
  *	have changed. The actual parameter values are available in
  *	struct wiphy. If returning an error, no value should be changed.
  */
-static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, 
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+        int radio_idx,
+    #endif
+    u32 changed)
 {
     return 0;
 }
@@ -4294,6 +4298,9 @@ static int rwnx_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
 static int rwnx_cfg80211_set_tx_power(struct wiphy *wiphy,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
  struct wireless_dev *wdev,
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+ int radio_idx,
 #endif
                                       enum nl80211_tx_power_setting type, int mbm)
 {

--- a/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_rx.c
@@ -2368,7 +2368,11 @@ check_len_update:
         hdr = (struct ieee80211_hdr *)(skb->data + msdu_offset);
         rwnx_vif = rwnx_rx_get_vif(rwnx_hw, hw_rxhdr->flags_vif_idx);
         if (rwnx_vif) {
+            #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
             cfg80211_rx_spurious_frame(rwnx_vif->ndev, hdr->addr2, GFP_ATOMIC);
+            #else
+            cfg80211_rx_spurious_frame(rwnx_vif->ndev, hdr->addr2, UNKNOWN_LINK_ID, GFP_ATOMIC);
+            #endif
         }
         goto end;
     }
@@ -2618,8 +2622,15 @@ check_len_update:
                 }
 
                 if (hw_rxhdr->flags_is_4addr && !rwnx_vif->use_4addr) {
+                    #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 17, 0)
                     cfg80211_rx_unexpected_4addr_frame(rwnx_vif->ndev,
                                                        sta->mac_addr, GFP_ATOMIC);
+                    #else
+                    cfg80211_rx_unexpected_4addr_frame(rwnx_vif->ndev,
+                                                       sta->mac_addr, 
+                                                       UNKNOWN_LINK_ID,
+                                                       GFP_ATOMIC);
+                    #endif
                 }
             }
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_rx.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_rx.h
@@ -405,4 +405,8 @@ struct element {
 #endif
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
+#define UNKNOWN_LINK_ID -1
+#endif
+
 #endif /* _RWNX_RX_H_ */


### PR DESCRIPTION
modified:   aic8800_fdrv/rwnx_rx.h \
modified:   aic8800_fdrv/rwnx_rx.c \
modified:   aic8800_fdrv/rwnx_main.c

### rwnx_rx.h
add define __UNKNOWN_LINK_ID__ as -1

### rwnx_rx.c
for kernel < 6.17
- cfg80211_rx_spurious_frame(rwnx_vif->ndev, hdr->addr2, GFP_ATOMIC); 

for kernel >= 6.17
- cfg80211_rx_spurious_frame(rwnx_vif->ndev, hdr->addr2, UNKNOWN_LINK_ID, GFP_ATOMIC);

for kernel < 6.17
- cfg80211_rx_unexpected_4addr_frame(rwnx_vif->ndev, sta->mac_addr, GFP_ATOMIC);

for kernel >= 6.17
- cfg80211_rx_unexpected_4addr_frame(rwnx_vif->ndev, sta->mac_addr, UNKNOWN_LINK_ID, GFP_ATOMIC);

### rwnx_main.c
add __radio_idx__ parameter to __rwnx_cfg80211_set_tx_power__ and __rwnx_cfg80211_set_wiphy_params__ if kernel >= 6.17

Tested on OpenSUSE Tumbleweed kernel 6.17 with Tenda U11