### PR TITLE
Fix build error on kernel updates

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="aic8800"
 PACKAGE_VERSION="1.0.0"
-MAKE="make -C drivers/aic8800"
-CLEAN="make -C drivers/aic8800 clean"
+MAKE="KVER=${kernelver} 'make' -C drivers/aic8800"
+CLEAN="KVER=${kernelver} 'make' -C drivers/aic8800 clean"
 
 # Main module (aic8800_fdrv)
 BUILT_MODULE_NAME[0]="aic8800_fdrv"

--- a/drivers/aic8800/Makefile
+++ b/drivers/aic8800/Makefile
@@ -46,9 +46,9 @@ KDIR = /home/yaya/D/Workspace/CyberQuantum/JinHaoYue/amls905x3/SDK/20191101-0tt-
 endif
 
 ifeq ($(CONFIG_PLATFORM_UBUNTU), y)
-KDIR  = /lib/modules/$(shell uname -r)/build
+KVER ?= $(shell uname -r)
+KDIR  = /lib/modules/$(KVER)/build
 PWD   = $(shell pwd)
-KVER = $(shell uname -r)
 MODDESTDIR = /lib/modules/$(KVER)/kernel/drivers/net/wireless/aic8800
 SUBARCH = $(shell uname -m | sed -e s/i.86/i386/ -e s/armv.l/arm/ -e s/aarch64/arm64/ -e s/loongarch64/loongarch/ -e s/loong64/loongarch/)
 ARCH ?= $(SUBARCH)


### PR DESCRIPTION
https://github.com/shenmintao/aic8800d80/issues/33#issuecomment-3963982897

這個 PR 修正了上述問題
MAKE="..." 必須加上 KVER=${kernelver}
這樣編譯時 compiler 才會使用正確的 kernel headers 來編譯。