### PR TITLE
Bluetooth firmware upload fix

### DIFF
--- a/drivers/aic8800/aic_load_fw/aic_compat_8800d80.c
+++ b/drivers/aic8800/aic_load_fw/aic_compat_8800d80.c
@@ -303,6 +303,7 @@ int system_config_8800d80(struct aic_usb_dev *usb_dev){
 		int syscfg_num;
 		int ret, cnt;
 		const u32 mem_addr = 0x40500000;
+		const u32 cache_mem_addr = 0x40100020;
 		struct dbg_mem_read_cfm rd_mem_addr_cfm;
 		ret = rwnx_send_dbg_mem_read_req(usb_dev, mem_addr, &rd_mem_addr_cfm);
 		if (ret) {
@@ -314,6 +315,19 @@ int system_config_8800d80(struct aic_usb_dev *usb_dev){
         }
 		chip_id = (u8)(rd_mem_addr_cfm.memdata >> 16);
 		printk("chip_id=%x, chip_mcu_id = %d\n", chip_id, chip_mcu_id);
+		if (chip_mcu_id) {
+			ret = rwnx_send_dbg_mem_read_req(usb_dev, cache_mem_addr, &rd_mem_addr_cfm);
+			if (ret) {
+				printk("%x rd fail: %d\n", mem_addr, ret);
+				return ret;
+			}
+			rd_mem_addr_cfm.memdata |= 0x01;
+			ret = rwnx_send_dbg_mem_write_req(usb_dev, cache_mem_addr, rd_mem_addr_cfm.memdata);
+			if (ret) {
+				printk("%x write fail: %d\n", cache_mem_addr, ret);
+				return ret;
+			}
+		}
     #if 1
 		syscfg_num = sizeof(syscfg_tbl_8800d80) / sizeof(u32) / 2;
 		for (cnt = 0; cnt < syscfg_num; cnt++) {


### PR DESCRIPTION
Setting bit 0 at 0x40100020 does something cache-related allowing correct writes and readback. DBG_MEM_WRITE_REQ seems to return a bogus value back in DBG_MEM_WRITE_CFM if it's cleared; I strongly suspect none of DBG_MEM_BLOCK_WRITE_REQ function correctly, too.
aicloadfw.Sys in Windows does this for any chip with MCU id bit 25 at 0x40500000 set.

The snippet in question was pulled verbatim from https://github.com/shenmintao/aic8800d80/blob/b771774f4064fa1ae991c260dd57a690d7fcee55/drivers/aic8800/aic8800_fdrv/aicwf_compat_8800dc.c#L3633

This patch makes aic_btusb redunant btw. Standard btusb works just fine.