### PR TITLE
Add kernel 7.x support: fix implicit-fallthrough warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This driver is for the AIC8800D80 chipset, supported by devices such as the Tend
 
 Added support for devices with Vendor ID 368B (tested).
 
-Tested on Linux kernel 6.16 with Ubuntu 25.04 and 6.1.0.27 with Debian 12.
+Tested on Linux kernel 6.16 with Ubuntu 25.04, 6.1.0.27 with Debian 12, and 7.0.5 (zen) with Arch Linux.
 
 > **Bluetooth Support**: The [`bluetooth`](https://github.com/shenmintao/aic8800d80/tree/bluetooth) branch fully supports Bluetooth. This main branch only provides Wi-Fi functionality. Please switch to the `bluetooth` branch if you need Bluetooth support.
 

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -1927,7 +1927,7 @@ static struct rwnx_vif *rwnx_interface_add(struct rwnx_hw *rwnx_hw,
         vif->ap.generation = 0;
         vif->ap.mesh_pm = NL80211_MESH_POWER_ACTIVE;
         vif->ap.next_mesh_pm = NL80211_MESH_POWER_ACTIVE;
-        // no break
+        fallthrough;
     case NL80211_IFTYPE_AP:
         INIT_LIST_HEAD(&vif->ap.sta_list);
         memset(&vif->ap.bcn, 0, sizeof(vif->ap.bcn));
@@ -2531,7 +2531,7 @@ static int rwnx_cfg80211_change_iface(struct wiphy *wiphy,
         INIT_LIST_HEAD(&vif->ap.proxy_list);
         vif->ap.create_path = false;
         vif->ap.generation = 0;
-        // no break
+        fallthrough;
     case NL80211_IFTYPE_AP:
     case NL80211_IFTYPE_P2P_GO:
         INIT_LIST_HEAD(&vif->ap.sta_list);
@@ -4789,6 +4789,7 @@ static int rwnx_cfg80211_mgmt_tx(struct wiphy *wiphy, struct wireless_dev *wdev,
     switch (RWNX_VIF_TYPE(rwnx_vif)) {
         case NL80211_IFTYPE_AP_VLAN:
             rwnx_vif = rwnx_vif->ap_vlan.master;
+            fallthrough;
         case NL80211_IFTYPE_AP:
         case NL80211_IFTYPE_P2P_GO:
         case NL80211_IFTYPE_MESH_POINT:
@@ -5145,7 +5146,7 @@ rwnx_cfg80211_tdls_mgmt(struct wiphy *wiphy,
             printk("%s: only one TDLS link is supported!\n", __func__);
             status_code = WLAN_STATUS_REQUEST_DECLINED;
         }
-        /* fall-through */
+        fallthrough;
     case WLAN_TDLS_SETUP_REQUEST:
     case WLAN_TDLS_TEARDOWN:
     case WLAN_TDLS_DISCOVERY_REQUEST:
@@ -5625,6 +5626,7 @@ int rwnx_fill_station_info(struct rwnx_sta *sta, struct rwnx_vif *vif,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
 	case FORMATMOD_HE_MU:
 		sinfo->rxrate.he_ru_alloc = rx_vect1->he.ru_size;
+		fallthrough;
 	case FORMATMOD_HE_SU:
 	case FORMATMOD_HE_ER:
 		sinfo->rxrate.flags = RATE_INFO_FLAGS_HE_MCS;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_tx.c
@@ -617,7 +617,7 @@ int rwnx_send_add_if(struct rwnx_hw *rwnx_hw, const unsigned char *mac,
     //case NL80211_IFTYPE_P2P_DEVICE:
     case NL80211_IFTYPE_P2P_CLIENT:
         add_if_req_param->p2p = true;
-        // no break
+        fallthrough;
     #endif /* CONFIG_RWNX_FULLMAC */
     case NL80211_IFTYPE_STATION:
         add_if_req_param->type = MM_STA;
@@ -630,7 +630,7 @@ int rwnx_send_add_if(struct rwnx_hw *rwnx_hw, const unsigned char *mac,
     #ifdef CONFIG_RWNX_FULLMAC
     case NL80211_IFTYPE_P2P_GO:
         add_if_req_param->p2p = true;
-        // no break
+        fallthrough;
     #endif /* CONFIG_RWNX_FULLMAC */
     case NL80211_IFTYPE_AP:
         add_if_req_param->type = MM_AP;
@@ -1709,6 +1709,7 @@ int rwnx_send_vendor_hwconfig_req(struct rwnx_hw *rwnx_hw, uint32_t hwconfig_id,
 			printk("get_chip_temp err=%d\n", error);
 			}
 		}
+		fallthrough;
 	case CUSTOMIZED_FREQ_REQ:
 		/* Build the CUSTOMIZED_FREQ_REQ message */
 		req5 = rwnx_msg_zalloc(MM_SET_VENDOR_HWCONFIG_REQ, TASK_MM, DRV_TASK_ID, sizeof(struct mm_set_customized_freq_req));

--- a/drivers/aic8800/aic8800_fdrv/rwnx_txq.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_txq.c
@@ -638,6 +638,7 @@ void rwnx_txq_vif_for_each_sta(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_vi
     }
     case NL80211_IFTYPE_AP_VLAN:
         rwnx_vif = rwnx_vif->ap_vlan.master;
+        fallthrough;
     case NL80211_IFTYPE_AP:
     case NL80211_IFTYPE_MESH_POINT:
     case NL80211_IFTYPE_P2P_GO:


### PR DESCRIPTION
## Summary

- Replace `// no break` and `/* fall-through */` comments with the kernel-standard `fallthrough;` annotation
- Update README to document kernel 7.x as tested/supported

## Background

The driver already compiles cleanly against Linux 7.x — no API changes were needed. The `fallthrough;` keyword was introduced in kernel 5.4 and is the required way to annotate intentional switch-case fallthroughs. The old `// no break` comments are not recognized by GCC's `-Wimplicit-fallthrough` and produce warnings that can become errors in stricter kernel build configurations.

## Files changed

- `rwnx_main.c` — 4 fallthrough annotations (NL80211_IFTYPE_AP_VLAN, NL80211_MESH_POINT, TDLS, HE_MU)
- `rwnx_msg_tx.c` — 3 fallthrough annotations (P2P_CLIENT→STA, P2P_GO→AP, CHIP_TEMP_GET_REQ)
- `rwnx_txq.c` — 1 fallthrough annotation (NL80211_IFTYPE_AP_VLAN)
- `README.md` — add kernel 7.0.5-zen to tested list

## Test

Built and loaded successfully on:
- Kernel `7.0.5-zen1-1-zen` (Arch Linux)
- Device: `Bus 001 Device 005: ID 368b:8d84 AICSemi AIC 8800D80`
- Zero compilation errors, zero fallthrough warnings