### PR TITLE
Fix Linux 7.1 build compatibility (cfg80211 API and TDLS changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.o
+*.ko
+*.cmd
+.*.o.cmd
+.module-common.o
+

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="aic8800"
 PACKAGE_VERSION="1.0.0"
-MAKE="KVER=${kernelver} KDIR=/lib/modules/${kernelver}/build 'make' -C drivers/aic8800"
+MAKE="KVER=${kernelver} KDIR=/lib/modules/${kernelver}/build 'make' -C drivers/aic8800 LLVM=1"
 CLEAN="KVER=${kernelver} KDIR=/lib/modules/${kernelver}/build 'make' -C drivers/aic8800 clean"
 
 # Main module (aic8800_fdrv)

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -2941,6 +2941,16 @@ bool key_flag = false;
  * @add_key: add a key with the given parameters. @mac_addr will be %NULL
  *	when adding a group key.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_add_key(struct wiphy *wiphy, struct wireless_dev *wdev,
+                                 int link_id,
+                                 u8 key_index, bool pairwise, const u8 *mac_addr,
+                                 struct key_params *params)
+{
+    struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+    struct net_device *netdev = wdev->netdev;
+    struct rwnx_vif *vif = netdev_priv(netdev);
+#else
 static int rwnx_cfg80211_add_key(struct wiphy *wiphy, struct net_device *netdev,
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
                                                                  int link_id,
@@ -2950,6 +2960,7 @@ static int rwnx_cfg80211_add_key(struct wiphy *wiphy, struct net_device *netdev,
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_vif *vif = netdev_priv(netdev);
+#endif
     int i, error = 0;
     struct mm_key_add_cfm key_add_cfm;
     u8_l cipher = 0;
@@ -3056,6 +3067,18 @@ static int rwnx_cfg80211_add_key(struct wiphy *wiphy, struct net_device *netdev,
  *	not possible to retrieve the key, -ENOENT if it doesn't exist.
  *
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_get_key(struct wiphy *wiphy, struct wireless_dev *wdev,
+                                 int link_id,
+                                 u8 key_index, bool pairwise, const u8 *mac_addr,
+                                 void *cookie,
+                                 void (*callback)(void *cookie, struct key_params*))
+{
+    RWNX_DBG(RWNX_FN_ENTRY_STR);
+
+    return -1;
+}
+#else
 static int rwnx_cfg80211_get_key(struct wiphy *wiphy, struct net_device *netdev,
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
                                                                  int link_id,
@@ -3069,12 +3092,22 @@ static int rwnx_cfg80211_get_key(struct wiphy *wiphy, struct net_device *netdev,
 
     return -1;
 }
+#endif
 
 
 /**
  * @del_key: remove a key given the @mac_addr (%NULL for a group key)
  *	and @key_index, return -ENOENT if the key doesn't exist.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_del_key(struct wiphy *wiphy, struct wireless_dev *wdev,
+                                 int link_id,
+                                 u8 key_index, bool pairwise, const u8 *mac_addr)
+{
+    struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+    struct net_device *netdev = wdev->netdev;
+    struct rwnx_vif *vif = netdev_priv(netdev);
+#else
 static int rwnx_cfg80211_del_key(struct wiphy *wiphy, struct net_device *netdev,
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
                                                                  int link_id,
@@ -3084,6 +3117,7 @@ static int rwnx_cfg80211_del_key(struct wiphy *wiphy, struct net_device *netdev,
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_vif *vif = netdev_priv(netdev);
+#endif
     int error;
     struct rwnx_sta *sta = NULL;
     struct rwnx_key *rwnx_key;
@@ -3130,6 +3164,15 @@ static int rwnx_cfg80211_set_default_key(struct wiphy *wiphy,
 /**
  * @set_default_mgmt_key: set the default management frame key on an interface
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
+                                              struct wireless_dev *wdev,
+                                              int link_id,
+                                              u8 key_index)
+{
+    return 0;
+}
+#else
 static int rwnx_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
                                               struct net_device *netdev,
 #if (LINUX_VERSION_CODE >= HIGH_KERNEL_VERSION2)
@@ -3139,6 +3182,7 @@ static int rwnx_cfg80211_set_default_mgmt_key(struct wiphy *wiphy,
 {
     return 0;
 }
+#endif
 
 /**
  * @connect: Connect to the ESS with the specified parameters. When connected,
@@ -3447,6 +3491,16 @@ static int rwnx_cfg80211_external_auth(struct wiphy *wiphy, struct net_device *d
 /**
  * @add_station: Add a new station.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
+                                     struct wireless_dev *wdev,
+                                     const u8 *mac,
+                                     struct station_parameters *params)
+{
+    struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+    struct net_device *dev = wdev->netdev;
+    struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#else
 static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
 	struct net_device *dev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
@@ -3458,6 +3512,7 @@ static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#endif
     struct me_sta_add_cfm me_sta_add_cfm;
     int error = 0;
 
@@ -3598,6 +3653,15 @@ static int rwnx_cfg80211_add_station(struct wiphy *wiphy,
 /**
  * @del_station: Remove a station
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_del_station_compat(struct wiphy *wiphy,
+                                            struct wireless_dev *wdev,
+                                            struct station_del_parameters *params)
+{
+    struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+    struct net_device *dev = wdev->netdev;
+    struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#else
 static int rwnx_cfg80211_del_station_compat(struct wiphy *wiphy,
                                             struct net_device *dev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
@@ -3611,6 +3675,7 @@ static int rwnx_cfg80211_del_station_compat(struct wiphy *wiphy,
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#endif
     struct rwnx_sta *cur, *tmp;
     int error = 0, found = 0;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
@@ -3889,6 +3954,16 @@ void apm_probe_sta_work_process(struct work_struct *work)
  *	them, also against the existing state! Drivers must call
  *	cfg80211_check_station_change() to validate the information.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_change_station(struct wiphy *wiphy,
+                                        struct wireless_dev *wdev,
+                                        const u8 *mac,
+                                        struct station_parameters *params)
+{
+    struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
+    struct net_device *dev = wdev->netdev;
+    struct rwnx_vif *vif = netdev_priv(dev);
+#else
 static int rwnx_cfg80211_change_station(struct wiphy *wiphy, struct net_device *dev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
@@ -3899,6 +3974,7 @@ static int rwnx_cfg80211_change_station(struct wiphy *wiphy, struct net_device *
 {
     struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_vif *vif = netdev_priv(dev);
+#endif
     struct rwnx_sta *sta;
 
     sta = rwnx_get_sta(rwnx_hw, mac);
@@ -5881,6 +5957,15 @@ int rwnx_fill_station_info(struct rwnx_sta *sta, struct rwnx_vif *vif,
 /**
  * @get_station: get station information for the station identified by @mac
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_get_station(struct wiphy *wiphy,
+                                     struct wireless_dev *wdev,
+                                     const u8 *mac,
+                                     struct station_info *sinfo)
+{
+    struct net_device *dev = wdev->netdev;
+    struct rwnx_vif *vif = netdev_priv(dev);
+#else
 static int rwnx_cfg80211_get_station(struct wiphy *wiphy,
 	struct net_device *dev,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
@@ -5891,6 +5976,7 @@ static int rwnx_cfg80211_get_station(struct wiphy *wiphy,
 	struct station_info *sinfo)
 {
     struct rwnx_vif *vif = netdev_priv(dev);
+#endif
     struct rwnx_sta *sta = NULL;
 
     if (RWNX_VIF_TYPE(vif) == NL80211_IFTYPE_MONITOR)
@@ -5923,10 +6009,18 @@ static int rwnx_cfg80211_get_station(struct wiphy *wiphy,
 /**
  * @dump_station: dump station callback -- resume dump at index @idx
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int rwnx_cfg80211_dump_station(struct wiphy *wiphy, struct wireless_dev *wdev,
+                                      int idx, u8 *mac, struct station_info *sinfo)
+{
+    struct net_device *dev = wdev->netdev;
+    struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#else
 static int rwnx_cfg80211_dump_station(struct wiphy *wiphy, struct net_device *dev,
                                       int idx, u8 *mac, struct station_info *sinfo)
 {
     struct rwnx_vif *rwnx_vif = netdev_priv(dev);
+#endif
     //struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_sta *sta_iter, *sta = NULL;
     //struct mesh_peer_info_cfm peer_info_cfm;

--- a/drivers/aic8800/aic8800_fdrv/rwnx_tdls.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_tdls.c
@@ -115,12 +115,21 @@ rwnx_prep_tdls_direct(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_vif,
 
     switch (action_code) {
     case WLAN_PUB_ACTION_TDLS_DISCOVER_RES:
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+        skb_put(skb, 2 + sizeof(mgmt->u.action.tdls_discover_resp));
+        mgmt->u.action.category = WLAN_CATEGORY_PUBLIC;
+        mgmt->u.action.action_code = WLAN_PUB_ACTION_TDLS_DISCOVER_RES;
+        mgmt->u.action.tdls_discover_resp.dialog_token = dialog_token;
+        mgmt->u.action.tdls_discover_resp.capability =
+            cpu_to_le16(rwnx_get_tdls_sta_capab(rwnx_vif, status_code));
+#else
         skb_put(skb, 1 + sizeof(mgmt->u.action.u.tdls_discover_resp));
         mgmt->u.action.category = WLAN_CATEGORY_PUBLIC;
         mgmt->u.action.u.tdls_discover_resp.action_code = WLAN_PUB_ACTION_TDLS_DISCOVER_RES;
         mgmt->u.action.u.tdls_discover_resp.dialog_token = dialog_token;
         mgmt->u.action.u.tdls_discover_resp.capability =
             cpu_to_le16(rwnx_get_tdls_sta_capab(rwnx_vif, status_code));
+#endif
         break;
     default:
         return -EINVAL;


### PR DESCRIPTION
## Summary

This PR fixes build failures against Linux 7.1 caused by cfg80211 API changes and TDLS structure updates.

### Changes

* Update cfg80211 callback handling for kernels using `struct wireless_dev` in `cfg80211_ops`.
* Add compatibility wrappers while preserving support for older kernels.
* Fix TDLS discovery response handling after `ieee80211_mgmt` action frame layout changes.
* Update DKMS configuration as required for successful builds.

### Tested on

* Distribution: PikaOS
* Kernel: 7.1.0-pikaos
* Architecture: x86_64

### Validation

* DKMS build completed successfully.
* Modules load successfully after installation.
* Driver initializes correctly on supported AIC8800 devices.

Tested on PikaOS. The same fixes may also help other distributions shipping Linux 7.1 or newer kernels environments).