### PR TITLE
fix: build the Bazzite package on Linux 7.2

### DIFF
--- a/bazzite/aic8800d80.spec
+++ b/bazzite/aic8800d80.spec
@@ -1,11 +1,11 @@
-%global commit 13baa9b0b1692f94233bcf6e752060b408062026
+%global commit e93a7d2b6b9634acefc2aae2891e787fb48fdb01
 %global shortcommit %(echo %{commit} | cut -c1-7)
 %global debug_package %{nil}
 %{!?kver:%global kver %(uname -r)}
 
 Name:           aic8800d80
 Version:        %{shortcommit}
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        AIC8800 USB Wi-Fi, Bluetooth firmware, and ZLP quirk driver
 
 License:        GPL-2.0-only
@@ -78,6 +78,10 @@ cp -a fw/aic8800* %{buildroot}/usr/lib/firmware/
 /usr/lib/firmware/aic8800*
 
 %changelog
+* Fri Aug 21 2026 Heyde Moura <moura.heyde@gmail.com> - e93a7d2-1
+- Build the current main branch, which carries the Linux 7.2 cfg80211 and
+  strncpy() fixes needed to compile on Bazzite 44.
+
 * Tue Jul 28 2026 ccyuen1 - 13baa9b-2
 - Disable automatic creation of debuginfo packages to fix issue #77.
 - Require usb_modeswitch as package dependency instead of file dependency to fix issue #77.


### PR DESCRIPTION
## Problem

`bazzite/aic8800d80.spec` still pins `%global commit 13baa9b`, which predates 40379fe ("fix: support Linux 7.2 cfg80211 API"). Following `bazzite/README.md` on Bazzite 44 (kernel 7.2) therefore still fails in `%build`:

```
rwnx_msg_tx.c:4852:5: error: implicit declaration of function 'strncpy' [-Wimplicit-function-declaration]
rwnx_main.c:6553:26: error: initialization of 'int (*)(..., u64 *, const u8 *)' from incompatible
                            pointer type 'int (*)(..., u64 *)' [-Wincompatible-pointer-types]
      .remain_on_channel = rwnx_cfg80211_remain_on_channel,
```

The driver sources on `main` already handle both cases; only the pinned snapshot is stale.

## Change

- Pin `%global commit` to the current `main` (e93a7d2).
- Reset `Release` to 1 for the new snapshot and add a changelog entry.

## Verification

Built on Bazzite 44, kernel `7.2.0-ogc4.1.fc44.x86_64`:

```
rpmbuild --define "kver $(uname -r)" -bb $HOME/rpmbuild/SPECS/aic8800d80.spec
Wrote: ~/rpmbuild/RPMS/x86_64/aic8800d80-e93a7d2-1.fc44.x86_64.rpm
```

The package contains `aic8800_fdrv.ko`, `aic_load_fw.ko` and `aic_zlp_quirk.ko`, all with vermagic `7.2.0-ogc4.1.fc44.x86_64`, plus the firmware, udev rule and usb_modeswitch config as before.