### PR TITLE
fix: support Linux 7.3 cfg80211 API

### DIFF
--- a/drivers/aic8800/aic8800_fdrv/rwnx_defs.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_defs.h
@@ -335,6 +335,12 @@ struct apm_probe_sta {
        u8 sta_mac_addr[6];
        u8 vif_idx;
        u64 probe_id;
+       /*
+        * 7.3+ only: the cookie cfg80211_ops::probe_peer() was called with,
+        * echoed back via cfg80211_probe_status() once the probe completes.
+        * See rwnx_cfg80211_probe_client().
+        */
+       u64 cookie;
        struct work_struct apmprobestaWork;
        struct workqueue_struct *apmprobesta_wq;
 };
@@ -675,6 +681,16 @@ struct rwnx_roc_elem {
     bool mgmt_roc;
     /* Indicate if we have switch on the RoC channel */
     bool on_chan;
+    /*
+     * The cookie reported to cfg80211 for this RoC, via
+     * cfg80211_ready_on_channel() / cfg80211_remain_on_channel_expired().
+     * On 7.3+, for a RoC started directly by cfg80211_ops::remain_on_channel(),
+     * this is the cookie cfg80211 pre-assigned; on every older kernel, and
+     * always for the purely-internal RoC started from inside mgmt_tx, it is
+     * rwnx_hw->roc_cookie_cnt at RoC-start time. See
+     * rwnx_cfg80211_remain_on_channel_().
+     */
+    u64 cookie;
 };
 
 /* Structure containing channel survey information received from MAC */

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.c
@@ -3940,7 +3940,21 @@ void apm_probe_sta_work_process(struct work_struct *work)
 	   spin_unlock_bh(&rwnx_vif->rwnx_hw->cb_lock);
 
        printk("sta %pM found = %d\n", mac, found);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+       /*
+        * 7.3 added an MLO link_id parameter between cookie and acked. This
+        * driver has no MLO support, and -1 is the documented value for
+        * "non-MLO" (see the cfg80211_probe_status() kerneldoc). The cookie
+        * source also changes here: sta_probe.cookie is the value cfg80211
+        * pre-assigned via probe_peer(), which now must be echoed back
+        * instead of the driver's own probe_id counter -- see
+        * rwnx_cfg80211_probe_client().
+        */
+       if(found)
+               cfg80211_probe_status(rwnx_vif->ndev, mac, (u64)rwnx_vif->sta_probe.cookie, -1, 1, 0, false, GFP_ATOMIC);
+       else
+               cfg80211_probe_status(rwnx_vif->ndev, mac, (u64)rwnx_vif->sta_probe.cookie, -1, 0, 0, false, GFP_ATOMIC);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
        if(found)
                cfg80211_probe_status(rwnx_vif->ndev, mac, (u64)rwnx_vif->sta_probe.probe_id, 1, 0, false, GFP_ATOMIC);
        else
@@ -4497,11 +4511,18 @@ int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
 
 
 /**
- * @probe_client: probe an associated client, must return a cookie that it
- *	later passes to cfg80211_probe_status().
+ * @probe_peer: probe an associated client, must return a cookie that it
+ *	later passes to cfg80211_probe_status(). Renamed from @probe_client
+ *	upstream; kept as rwnx_cfg80211_probe_client() here since only the
+ *	cfg80211_ops field name changed, not this driver's own naming.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+int rwnx_cfg80211_probe_client(struct wiphy *wiphy, struct net_device *dev,
+            const u8 *peer, u64 cookie)
+#else
 int rwnx_cfg80211_probe_client(struct wiphy *wiphy, struct net_device *dev,
             const u8 *peer, u64 *cookie)
+#endif
 {
     //struct rwnx_hw *rwnx_hw = wiphy_priv(wiphy);
     struct rwnx_vif *vif = netdev_priv(dev);
@@ -4527,7 +4548,17 @@ int rwnx_cfg80211_probe_client(struct wiphy *wiphy, struct net_device *dev,
     memcpy(vif->sta_probe.sta_mac_addr, peer, 6);
     queue_work(vif->sta_probe.apmprobesta_wq, &vif->sta_probe.apmprobestaWork);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+    /*
+     * 7.3 made this an input parameter: cfg80211 pre-assigns the cookie
+     * before calling us instead of us inventing one and returning it. Save
+     * it so the async probe-status work above can echo it back via
+     * cfg80211_probe_status() once the probe completes.
+     */
+    vif->sta_probe.cookie = cookie;
+#else
     *cookie = vif->sta_probe.probe_id;
+#endif
 
     return 0;
 }
@@ -4827,7 +4858,23 @@ rwnx_cfg80211_remain_on_channel_(struct wiphy *wiphy,
     if (error == 0) {
 
         /* Set the cookie value */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+        /*
+         * mgmt_roc_flag is false only for the direct cfg80211
+         * .remain_on_channel call path (see rwnx_cfg80211_remain_on_channel()
+         * below), where on 7.3+ *cookie already holds the value cfg80211
+         * pre-assigned and must be honored rather than overwritten. The
+         * purely-internal RoC this function also serves (started from
+         * inside mgmt_tx, mgmt_roc_flag true) never goes through that
+         * cfg80211 op, so there is no pre-assigned value to honor there --
+         * keep inventing one, exactly as on every older kernel.
+         */
+        if (mgmt_roc_flag)
+            *cookie = (u64)(rwnx_hw->roc_cookie_cnt);
+#else
         *cookie = (u64)(rwnx_hw->roc_cookie_cnt);
+#endif
+        roc_elem->cookie = *cookie;
         if(roc_cfm.status) {
             // failed to roc
             rwnx_hw->roc_elem = NULL;
@@ -4857,18 +4904,43 @@ rwnx_cfg80211_remain_on_channel(struct wiphy *wiphy,
                             #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
                                 enum nl80211_channel_type channel_type,
                             #endif
-                                unsigned int duration, u64 *cookie
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
+                                unsigned int duration,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+                                /*
+                                 * 7.3 made this cookie an input parameter: cfg80211
+                                 * pre-assigns it before calling us instead of us
+                                 * inventing one and returning it. See
+                                 * rwnx_cfg80211_remain_on_channel_().
+                                 */
+                                u64 cookie, const u8 *rx_addr
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0)
                                 /*
                                  * 7.2 added an optional receive address filter for the off-channel
                                  * period. cfg80211 refuses a non-NULL one unless the driver sets
                                  * NL80211_EXT_FEATURE_ROC_ADDR_FILTER, which this one does not, so it
                                  * is always NULL here. mac80211 ignores it in the same way.
                                  */
-                                , const u8 *rx_addr
+                                u64 *cookie, const u8 *rx_addr
+#else
+                                u64 *cookie
 #endif
                                 )
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+    u64 local_cookie = cookie;
+
+	return rwnx_cfg80211_remain_on_channel_(wiphy,
+                            #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
+                                wdev,
+                            #else
+                                dev,
+                            #endif
+                                chan,
+                            #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
+                                channel_type,
+                            #endif
+                                duration, &local_cookie, false);
+#else
 	return rwnx_cfg80211_remain_on_channel_(wiphy,
                             #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
                                 wdev,
@@ -4880,6 +4952,7 @@ rwnx_cfg80211_remain_on_channel(struct wiphy *wiphy,
                                 channel_type,
                             #endif
                                 duration, cookie, false);
+#endif
 }
 
 /**
@@ -5057,7 +5130,17 @@ struct ieee80211_channel *rwnx_cfg80211_get_channel(struct wiphy *wiphy)
 /**
  * @mgmt_tx: Transmit a management frame.
  */
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+static int rwnx_cfg80211_mgmt_tx(struct wiphy *wiphy, struct wireless_dev *wdev,
+                                 struct cfg80211_mgmt_tx_params *params,
+                                 /*
+                                  * 7.3 made this cookie an input parameter: cfg80211
+                                  * pre-assigns it before calling us instead of us
+                                  * inventing one and returning it. See
+                                  * rwnx_start_mgmt_xmit().
+                                  */
+                                 u64 cookie)
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
 static int rwnx_cfg80211_mgmt_tx(struct wiphy *wiphy, struct wireless_dev *wdev,
                                  struct cfg80211_mgmt_tx_params *params,
                                  u64 *cookie)
@@ -5190,8 +5273,13 @@ static int rwnx_cfg80211_mgmt_tx(struct wiphy *wiphy, struct wireless_dev *wdev,
     #endif
 
 send_frame:
-    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
-    return rwnx_start_mgmt_xmit(rwnx_vif, rwnx_sta, params, offchan, cookie);
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0))
+    {
+        u64 local_cookie = cookie;
+        return rwnx_start_mgmt_xmit(rwnx_vif, rwnx_sta, params, offchan, &local_cookie, true);
+    }
+    #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
+    return rwnx_start_mgmt_xmit(rwnx_vif, rwnx_sta, params, offchan, cookie, false);
     #else
     return rwnx_start_mgmt_xmit(rwnx_vif, rwnx_sta, channel, offchan, wait, buf, len, no_cck, dont_wait_for_ack, cookie);
     #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) */
@@ -6552,7 +6640,11 @@ static struct cfg80211_ops rwnx_cfg80211_ops = {
     .change_beacon = rwnx_cfg80211_change_beacon,
     .stop_ap = rwnx_cfg80211_stop_ap,
     .set_monitor_channel = rwnx_cfg80211_set_monitor_channel,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+    .probe_peer = rwnx_cfg80211_probe_client,
+#else
     .probe_client = rwnx_cfg80211_probe_client,
+#endif
 //    .mgmt_frame_register = rwnx_cfg80211_mgmt_frame_register,
     .set_wiphy_params = rwnx_cfg80211_set_wiphy_params,
     .set_txq_params = rwnx_cfg80211_set_txq_params,

--- a/drivers/aic8800/aic8800_fdrv/rwnx_main.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_main.h
@@ -99,8 +99,13 @@ int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
 int rwnx_cfg80211_set_monitor_channel_(struct wiphy *wiphy,
                                              struct cfg80211_chan_def *chandef);
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 3, 0)
+int rwnx_cfg80211_probe_client(struct wiphy *wiphy, struct net_device *dev,
+            const u8 *peer, u64 cookie);
+#else
 int rwnx_cfg80211_probe_client(struct wiphy *wiphy, struct net_device *dev,
             const u8 *peer, u64 *cookie);
+#endif
 void rwnx_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
                    struct net_device *dev,

--- a/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_msg_rx.c
@@ -123,13 +123,13 @@ static inline int rwnx_rx_chan_switch_ind(struct rwnx_hw *rwnx_hw,
             if (!roc_elem->mgmt_roc) {
                 /* Inform the host that we have switch on the indicated off-channel */
                 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0)
-                cfg80211_ready_on_channel(roc_elem->wdev->netdev, (u64)(rwnx_hw->roc_cookie_cnt),
+                cfg80211_ready_on_channel(roc_elem->wdev->netdev, roc_elem->cookie,
                                         roc_elem->chan, NL80211_CHAN_HT20, roc_elem->duration, GFP_ATOMIC);
                 #elif LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
-                cfg80211_ready_on_channel(roc_elem->wdev, (u64)(rwnx_hw->roc_cookie_cnt),
+                cfg80211_ready_on_channel(roc_elem->wdev, roc_elem->cookie,
                                         roc_elem->chan, NL80211_CHAN_HT20, roc_elem->duration, GFP_ATOMIC);
                 #else
-                cfg80211_ready_on_channel(roc_elem->wdev, (u64)(rwnx_hw->roc_cookie_cnt),
+                cfg80211_ready_on_channel(roc_elem->wdev, roc_elem->cookie,
                                         roc_elem->chan, roc_elem->duration, GFP_ATOMIC);
                 #endif
             }
@@ -245,13 +245,13 @@ static inline int rwnx_rx_remain_on_channel_exp_ind(struct rwnx_hw *rwnx_hw,
         /* Inform the host that off-channel period has expired */
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0)
-	cfg80211_remain_on_channel_expired(roc_elem->wdev->netdev, (u64)(rwnx_hw->roc_cookie_cnt),
+	cfg80211_remain_on_channel_expired(roc_elem->wdev->netdev, roc_elem->cookie,
                                            roc_elem->chan, NL80211_CHAN_HT20, GFP_ATOMIC);
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0)
-	cfg80211_remain_on_channel_expired(roc_elem->wdev, (u64)(rwnx_hw->roc_cookie_cnt),
+	cfg80211_remain_on_channel_expired(roc_elem->wdev, roc_elem->cookie,
                                            roc_elem->chan, NL80211_CHAN_HT20, GFP_ATOMIC);
 #else
-        cfg80211_remain_on_channel_expired(roc_elem->wdev, (u64)(rwnx_hw->roc_cookie_cnt),
+        cfg80211_remain_on_channel_expired(roc_elem->wdev, roc_elem->cookie,
                                            roc_elem->chan, GFP_ATOMIC);
 #endif
     }

--- a/drivers/aic8800/aic8800_fdrv/rwnx_tdls.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_tdls.c
@@ -775,7 +775,7 @@ rwnx_tdls_send_mgmt_packet_data(struct rwnx_hw *rwnx_hw, struct rwnx_vif *rwnx_v
 
         params.len = skb->len;
         params.buf = skb->data;
-        ret = rwnx_start_mgmt_xmit(rwnx_vif, NULL, &params, false, &cookie);
+        ret = rwnx_start_mgmt_xmit(rwnx_vif, NULL, &params, false, &cookie, false);
         #else
         ret = rwnx_start_mgmt_xmit(rwnx_vif, NULL, NULL, false, 0, skb->data, skb->len, false, false, &cookie);
         #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0) */

--- a/drivers/aic8800/aic8800_fdrv/rwnx_tx.c
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_tx.c
@@ -1638,7 +1638,7 @@ free:
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
 int rwnx_start_mgmt_xmit(struct rwnx_vif *vif, struct rwnx_sta *sta,
                          struct cfg80211_mgmt_tx_params *params, bool offchan,
-                         u64 *cookie)
+                         u64 *cookie, bool use_given_cookie)
 #else
 int rwnx_start_mgmt_xmit(struct rwnx_vif *vif, struct rwnx_sta *sta,
                          struct ieee80211_channel *channel, bool offchan,
@@ -1703,7 +1703,18 @@ int rwnx_start_mgmt_xmit(struct rwnx_vif *vif, struct rwnx_sta *sta,
         return -ENOMEM;
     }
 
-    *cookie = (unsigned long)skb;
+    /*
+     * use_given_cookie is true only for the direct cfg80211 .mgmt_tx call
+     * path on 7.3+, where *cookie already holds the value cfg80211
+     * pre-assigned and must be echoed back via cfg80211_mgmt_tx_status()
+     * later -- see rwnx_cfg80211_mgmt_tx(). TDLS's internal reuse of this
+     * function (use_given_cookie == false) never goes through that cfg80211
+     * op, so it still gets an invented, locally-unique cookie exactly as
+     * before this fix, and on every kernel older than 7.3 every caller
+     * passes use_given_cookie == false, also leaving this unchanged.
+     */
+    if (!use_given_cookie)
+        *cookie = (unsigned long)skb;
 
     /*
      * Move skb->data pointer in order to reserve room for rwnx_txhdr
@@ -1773,6 +1784,7 @@ int rwnx_start_mgmt_xmit(struct rwnx_vif *vif, struct rwnx_sta *sta,
     sw_txhdr->rwnx_sta = sta;
     sw_txhdr->rwnx_vif = vif;
     sw_txhdr->skb = skb;
+    sw_txhdr->cookie = *cookie;
     sw_txhdr->headroom = headroom;
     sw_txhdr->map_len = skb->len - offsetof(struct rwnx_txhdr, hw_hdr);
 #ifdef CONFIG_RWNX_AMSDUS_TX
@@ -2389,7 +2401,7 @@ int rwnx_txdatacfm(void *pthis, void *host_id)
 #endif
         /* Confirm transmission to CFG80211 */
         cfg80211_mgmt_tx_status(&sw_txhdr->rwnx_vif->wdev,
-                                (unsigned long)skb,
+                                sw_txhdr->cookie,
                                 (skb->data + sw_txhdr->headroom),
                                 sw_txhdr->frame_len,
                                 rwnx_txst.acknowledged,

--- a/drivers/aic8800/aic8800_fdrv/rwnx_tx.h
+++ b/drivers/aic8800/aic8800_fdrv/rwnx_tx.h
@@ -130,6 +130,11 @@ struct rwnx_sw_txhdr {
 #endif
 	u32 need_cfm;
     struct sk_buff *skb;
+    /*
+     * The cookie cfg80211_mgmt_tx_status() must report for this frame. Set
+     * in rwnx_start_mgmt_xmit() -- see the comment on use_given_cookie there.
+     */
+    u64 cookie;
 
     size_t map_len;
     dma_addr_t dma_addr;
@@ -158,7 +163,7 @@ netdev_tx_t rwnx_start_xmit(struct sk_buff *skb, struct net_device *dev);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
 int rwnx_start_mgmt_xmit(struct rwnx_vif *vif, struct rwnx_sta *sta,
                          struct cfg80211_mgmt_tx_params *params, bool offchan,
-                         u64 *cookie);
+                         u64 *cookie, bool use_given_cookie);
 #else
 int rwnx_start_mgmt_xmit(struct rwnx_vif *vif, struct rwnx_sta *sta,
                          struct ieee80211_channel *channel, bool offchan,


### PR DESCRIPTION
## What breaks

Building against Linux 7.3-rc1 fails with 5 errors, all from one batch of
cfg80211 API churn: `cfg80211_probe_status()` gained a new `link_id`
parameter, `probe_client` was renamed to `probe_peer`, and `mgmt_tx`,
`remain_on_channel` and `probe_peer` all changed their cookie parameter
from an output pointer (`u64 *cookie`) to an input value (`u64 cookie`) —
cfg80211 now pre-assigns the cookie before calling the driver instead of
the driver inventing one and returning it.

## Why this is more than a type fix

This driver invents its `mgmt_tx`/`remain_on_channel`/`probe_peer` cookies
locally (from a skb pointer, an internal `roc_cookie_cnt` counter, and an
internal `probe_id` counter respectively), and separately re-derives "the
same" value later when reporting completion via
`cfg80211_mgmt_tx_status()`, `cfg80211_ready_on_channel()`,
`cfg80211_remain_on_channel_expired()` and `cfg80211_probe_status()`. That
self-consistency is exactly what breaks once cfg80211 assigns the cookie
itself: the completion report has to echo back the value cfg80211 gave the
driver, not a locally re-derived one, or cfg80211 can't correlate the two
(this matters most for P2P/GO negotiation, which leans on `mgmt_tx` +
`mgmt_tx_status` cookie correlation).

Each of these ops is a thin wrapper around a lower-level helper that is
*also* called from a purely-internal path with no real cfg80211-assigned
cookie to honor (an internal remain-on-channel started from inside
`mgmt_tx`; TDLS's own reuse of `mgmt_tx`). Rather than changing those
helpers' contracts, each one gets a `bool` (`use_given_cookie` /
`mgmt_roc_flag`, the latter already existing for a similar reason) so the
internal callers keep inventing a cookie exactly as before, unchanged on
every kernel version, while the real cfg80211 op wrappers honor cfg80211's
pre-assigned value on 7.3+ and thread it through to the later completion
report. Full reasoning is in the commit message.

All version gates use `KERNEL_VERSION(7, 3, 0)`, matching how #86
(`40379fe`, "support Linux 7.2 cfg80211 API") gated the previous round of
this same kind of change.

## Testing

- Builds clean (zero errors, zero new warnings) with GCC against a freshly
  configured 7.3-rc1 tree.
- Builds clean with this project's own DKMS invocation (`LLVM=1`) against
  the real, installed `linux-cachyos-rc-bc250-headers` package for
  `7.3.0-rc1-1.81-cachyos-rc-bc250` on a BC-250 board with this exact
  AIC8800D80 adapter, producing `aic8800_fdrv.ko`, `aic_load_fw.ko` and
  `aic_zlp_quirk.ko`.
- I have not yet booted that board into the 7.3-rc1 kernel to test the
  module loading and an actual WiFi connection at runtime (it currently
  runs the 7.2 kernel where this driver already works) — happy to do that
  and report back if useful before merge.

Also confirmed with `git merge-base --is-ancestor` against the actual
kernel source that all four cfg80211 commits referenced in the commit
message first appear in the 7.3 cycle and are absent from 7.2, so 7.3.0 is
the right threshold rather than something looser.